### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/docker-develop.yml
+++ b/.github/workflows/docker-develop.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publich Docker
-      uses: elgohr/Publish-Docker-Github-Action@2.9
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: fwa-sempach/fwa-backend-sempach/fwa-backend-sempach:latest
         # The login username for the registry

--- a/.github/workflows/docker-master.yml
+++ b/.github/workflows/docker-master.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
     - uses: actions/checkout@v1
     - name: Publich Docker
-      uses: elgohr/Publish-Docker-Github-Action@2.9
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: fwa-sempach/fwa-backend-sempach/fwa-backend-sempach:stable
         # The login username for the registry


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore